### PR TITLE
8292487: Back out the fix forJDK-8281962 from jdk19u

### DIFF
--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -150,7 +150,7 @@ public class InflaterInputStream extends FilterInputStream {
         }
         try {
             int n;
-            do {
+            while ((n = inf.inflate(b, off, len)) == 0) {
                 if (inf.finished() || inf.needsDictionary()) {
                     reachEOF = true;
                     return -1;
@@ -158,7 +158,7 @@ public class InflaterInputStream extends FilterInputStream {
                 if (inf.needsInput()) {
                     fill();
                 }
-            } while ((n = inf.inflate(b, off, len)) == 0);
+            }
             return n;
         } catch (DataFormatException e) {
             String s = e.getMessage();


### PR DESCRIPTION
Hi,

Please review this PR which reverts the fix for [JDK-8281962](https://bugs.openjdk.org/browse/JDK-8281962) that unfortunately  introduced a regression.  The fix for the regression is being addressed via [JDK-8292327](https://bugs.openjdk.org/browse/JDK-8292327). 

Mach5 tiers 1-3 are currently running.

The intent is to give the fix for  [JDK-8292327](https://bugs.openjdk.org/browse/JDK-8292327) more time to bake in the main openjdk  workspace (for JDK 20) and in the meantime revert [JDK-8281962](https://bugs.openjdk.org/browse/JDK-8281962) in jdk19u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292487](https://bugs.openjdk.org/browse/JDK-8292487): Back out the fix forJDK-8281962 from jdk19u


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/jdk19u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/11.diff">https://git.openjdk.org/jdk19u/pull/11.diff</a>

</details>
