### PR TITLE
8227651: Tests fail with SSLProtocolException: Input record too big

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -596,7 +596,6 @@ sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-a
 
 sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
 
-javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java       8212096 generic-all
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all

--- a/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
@@ -38,6 +38,7 @@
  */
 
 import javax.net.ssl.*;
+import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.net.*;
 
@@ -93,10 +94,10 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -136,13 +137,13 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
@@ -145,10 +145,10 @@ public class SSLEngineExplorer extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -195,13 +195,13 @@ public class SSLEngineExplorer extends SSLEngineService {
         ssle.setEnabledProtocols(supportedProtocols);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -154,10 +154,10 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -209,13 +209,13 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
@@ -148,10 +148,10 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, buffer);
+            ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // send out application data
             deliver(ssle, sc);
@@ -213,13 +213,13 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, null);
+            ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
             // send out application data
             deliver(ssle, sc);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // check server name indication
             ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
@@ -136,10 +136,10 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -190,13 +190,13 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
@@ -145,10 +145,10 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -193,13 +193,13 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of https://bugs.openjdk.org/browse/JDK-8227651, commit [7b029ea6](https://github.com/openjdk/jdk/commit/7b029ea6ba1d44d361fdf980816732d8454b8194) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Daniel Jeliński on 10 Aug 2022 and was reviewed by Sean Coffey and Xue-Lei Andrew Fan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8227651](https://bugs.openjdk.org/browse/JDK-8227651): Tests fail with SSLProtocolException: Input record too big
 * [JDK-8212096](https://bugs.openjdk.org/browse/JDK-8212096): javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java failed intermittently due to SSLException: Tag mismatch


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jdk19u pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/12.diff">https://git.openjdk.org/jdk19u/pull/12.diff</a>

</details>
