### PR TITLE
8284977: MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist

### DIFF
--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -121,6 +121,11 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         Path filePath = Paths.get(UNIFIED.getPath(), file);
         try {
             String strVal = Files.lines(filePath).filter(l -> l.startsWith(metric)).collect(Collectors.joining());
+            if (strVal.isEmpty()) {
+                // sometimes the match for the metric does not exist, e.g. cpu.stat's nr_periods iff the controller
+                // is not enabled
+                return UNLIMITED;
+            }
             String[] keyValues = strVal.split("\\s+");
             String value = keyValues[1];
             return convertStringToLong(value);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of https://bugs.openjdk.org/browse/JDK-8284977, commit [444a0d98](https://github.com/openjdk/jdk/commit/444a0d98ac06ab043e3b11281234fd515abff302) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 15 Jun 2022 and was reviewed by Severin Gehwolf and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284977](https://bugs.openjdk.org/browse/JDK-8284977): MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jdk19u pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/13.diff">https://git.openjdk.org/jdk19u/pull/13.diff</a>

</details>
