### PR TITLE
8291508: Fix some tests with "requires vm.jvmti & vm.continuations"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001/TestDescription.java
@@ -41,6 +41,7 @@
  *     Fixed according to the 4480280 bug.
  *     Ported from JVMDI.
  *
+ * @requires vm.jvmti & vm.continuations
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jvmti.GetThreadInfo.thrinfo001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineVirtual/StressRedefineVirtual.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineVirtual/StressRedefineVirtual.java
@@ -27,6 +27,7 @@
  *
  * @key randomness
  *
+ * @requires vm.jvmti & vm.continuations
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jvmti.RedefineClasses.StressRedefine


### PR DESCRIPTION
I would like to backport this test fix. Low risk, only test changes. Clean backport. The changed tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291508](https://bugs.openjdk.org/browse/JDK-8291508): Fix some tests with "requires vm.jvmti & vm.continuations"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jdk19u pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/14.diff">https://git.openjdk.org/jdk19u/pull/14.diff</a>

</details>
