### PR TITLE
8291640: java/beans/XMLDecoder/8028054/Task.java should use the 3-arg Class.forName

### DIFF
--- a/test/jdk/java/beans/XMLDecoder/8028054/Task.java
+++ b/test/jdk/java/beans/XMLDecoder/8028054/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,8 +130,9 @@ abstract class Task<T> implements Runnable {
                 .map(s -> s.substring(s.indexOf("java")))
                 .collect(Collectors.toList());
 
+        ClassLoader scl = ClassLoader.getSystemClassLoader();
         for (String name : fileNames) {
-            classes.add(Class.forName(name));
+            classes.add(Class.forName(name, false, scl));
             if (count == classes.size()) {
                 break;
             }

--- a/test/jdk/java/beans/XMLDecoder/8028054/TestConstructorFinder.java
+++ b/test/jdk/java/beans/XMLDecoder/8028054/TestConstructorFinder.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Sergey Malenkov
  * @modules java.desktop/com.sun.beans.finder
  * @compile -XDignore.symbol.file TestConstructorFinder.java
- * @run main/othervm --enable-preview TestConstructorFinder
+ * @run main TestConstructorFinder
  */
 
 public class TestConstructorFinder {

--- a/test/jdk/java/beans/XMLDecoder/8028054/TestMethodFinder.java
+++ b/test/jdk/java/beans/XMLDecoder/8028054/TestMethodFinder.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Sergey Malenkov
  * @modules java.desktop/com.sun.beans.finder
  * @compile -XDignore.symbol.file TestMethodFinder.java
- * @run main/othervm --enable-preview TestMethodFinder
+ * @run main TestMethodFinder
  */
 
 public class TestMethodFinder {


### PR DESCRIPTION
I would like to backport this test fix. Low risk, only test changes. Clean backport. The changed tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291640](https://bugs.openjdk.org/browse/JDK-8291640): java/beans/XMLDecoder/8028054/Task.java should use the 3-arg Class.forName


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/jdk19u pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/15.diff">https://git.openjdk.org/jdk19u/pull/15.diff</a>

</details>
