### PR TITLE
8292654: G1 remembered set memory footprint regression after JDK-8286115

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -216,7 +216,7 @@
           "The threshold that defines (>=) a hot card.")                    \
           range(0, max_jubyte)                                              \
                                                                             \
-  develop(uint, G1RemSetArrayOfCardsEntriesBase, 4,                         \
+  develop(uint, G1RemSetArrayOfCardsEntriesBase, 8,                         \
           "Maximum number of entries per region in the Array of Cards "     \
           "card set container per MB of a heap region.")                    \
           range(1, 65536)                                                   \


### PR DESCRIPTION
Backport of 8a45abd5f3bb224e564c8e6087bac618147f484e, fixing memory regression.

Applies cleanly, works without a problem for a few weeks in tip.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292654](https://bugs.openjdk.org/browse/JDK-8292654): G1 remembered set memory footprint regression after JDK-8286115


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - no project role)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jdk19u pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/18.diff">https://git.openjdk.org/jdk19u/pull/18.diff</a>

</details>
