### PR TITLE
8291599: Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -931,6 +931,8 @@ private:
                                                 IdealLoopTree* outer_loop, Node* input_proj);
   Node* clone_skeleton_predicate_bool(Node* iff, Node* new_init, Node* new_stride, Node* control);
   static bool skeleton_predicate_has_opaque(IfNode* iff);
+  static void count_opaque_loop_nodes(Node* n, uint& init, uint& stride);
+  static bool subgraph_has_opaque(Node* n);
   static void get_skeleton_predicates(Node* predicate, Unique_Node_List& list, bool get_opaque = false);
   void update_main_loop_skeleton_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init, int stride_con);
   void copy_skeleton_predicates_to_post_loop(LoopNode* main_loop_head, CountedLoopNode* post_loop_head, Node* init, Node* stride);

--- a/src/hotspot/share/opto/split_if.cpp
+++ b/src/hotspot/share/opto/split_if.cpp
@@ -200,7 +200,7 @@ bool PhaseIdealLoop::split_up( Node *n, Node *blk1, Node *blk2 ) {
       return true;
     }
   }
-  if (n->Opcode() == Op_OpaqueLoopStride || n->Opcode() == Op_OpaqueLoopInit) {
+  if (subgraph_has_opaque(n)) {
     Unique_Node_List wq;
     wq.push(n);
     for (uint i = 0; i < wq.size(); i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestPhiInSkeletonPredicateExpression.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPhiInSkeletonPredicateExpression.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291599
+ * @summary Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:LoopMaxUnroll=0 TestPhiInSkeletonPredicateExpression
+ */
+
+public class TestPhiInSkeletonPredicateExpression {
+    private static int[] array1;
+    private static int[] array2;
+    private static int off;
+    private static volatile int barrier;
+
+    public static void main(String[] args) {
+        int[] array = new int[2000];
+        array1 = array;
+        array2 = array;
+        for (int i = 0; i < 20_000; i++) {
+            test1(1000, false);
+            test1(1000, true);
+            test2(1000, false);
+            test2(1000, true);
+        }
+    }
+
+    private static int test1(int stop, boolean flag) {
+        int v = 0;
+
+        for (int j = 1; j < 10; j *= 2) {
+            int[] array;
+            if (flag) {
+                if (array1 == null) {
+
+                }
+                array = array1;
+                barrier = 0x42;
+            } else {
+                if (array2 == null) {
+
+                }
+                array = array2;
+                barrier = 0x42;
+            }
+
+            int i = 0;
+            do {
+                synchronized (new Object()) {
+                }
+                v += array[i + off];
+                i++;
+            } while (i < stop);
+        }
+        return v;
+    }
+
+    private static int test2(int stop, boolean flag) {
+        int v = 0;
+
+        int[] array;
+        if (flag) {
+            if (array1 == null) {
+
+            }
+            array = array1;
+            barrier = 0x42;
+        } else {
+            if (array2 == null) {
+
+            }
+            array = array2;
+            barrier = 0x42;
+        }
+
+        int i = 0;
+        do {
+            synchronized (new Object()) {
+            }
+            v += array[i + off];
+            i++;
+        } while (i < stop);
+        return v;
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8291599](https://bugs.openjdk.java.net/browse/JDK-8291599). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291599](https://bugs.openjdk.org/browse/JDK-8291599): Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk19u pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/29.diff">https://git.openjdk.org/jdk19u/pull/29.diff</a>

</details>
