### PR TITLE
8293044: C1: Missing access check on non-accessible class

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2232,8 +2232,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
 
 void GraphBuilder::new_instance(int klass_index) {
   ValueStack* state_before = copy_state_exhandling();
-  bool will_link;
-  ciKlass* klass = stream()->get_klass(will_link);
+  ciKlass* klass = stream()->get_klass();
   assert(klass->is_instance_klass(), "must be an instance klass");
   NewInstance* new_instance = new NewInstance(klass->as_instance_klass(), state_before, stream()->is_unresolved_klass());
   _memory->new_instance(new_instance);
@@ -2248,8 +2247,7 @@ void GraphBuilder::new_type_array() {
 
 
 void GraphBuilder::new_object_array() {
-  bool will_link;
-  ciKlass* klass = stream()->get_klass(will_link);
+  ciKlass* klass = stream()->get_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_exhandling();
   NewArray* n = new NewObjectArray(klass, ipop(), state_before);
   apush(append_split(n));
@@ -2274,8 +2272,7 @@ bool GraphBuilder::direct_compare(ciKlass* k) {
 
 
 void GraphBuilder::check_cast(int klass_index) {
-  bool will_link;
-  ciKlass* klass = stream()->get_klass(will_link);
+  ciKlass* klass = stream()->get_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_for_exception();
   CheckCast* c = new CheckCast(klass, apop(), state_before);
   apush(append_split(c));
@@ -2295,8 +2292,7 @@ void GraphBuilder::check_cast(int klass_index) {
 
 
 void GraphBuilder::instance_of(int klass_index) {
-  bool will_link;
-  ciKlass* klass = stream()->get_klass(will_link);
+  ciKlass* klass = stream()->get_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_exhandling();
   InstanceOf* i = new InstanceOf(klass, apop(), state_before);
   ipush(append_split(i));
@@ -2331,8 +2327,7 @@ void GraphBuilder::monitorexit(Value x, int bci) {
 
 
 void GraphBuilder::new_multi_array(int dimensions) {
-  bool will_link;
-  ciKlass* klass = stream()->get_klass(will_link);
+  ciKlass* klass = stream()->get_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_exhandling();
 
   Values* dims = new Values(dimensions, dimensions, NULL);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1260,6 +1260,37 @@ JRT_END
 
 #else // DEOPTIMIZE_WHEN_PATCHING
 
+static bool is_patching_needed(JavaThread* current, Runtime1::StubID stub_id) {
+  if (stub_id == Runtime1::load_klass_patching_id ||
+      stub_id == Runtime1::load_mirror_patching_id) {
+    // last java frame on stack
+    vframeStream vfst(current, true);
+    assert(!vfst.at_end(), "Java frame must exist");
+
+    methodHandle caller_method(current, vfst.method());
+    int bci = vfst.bci();
+    Bytecodes::Code code = caller_method()->java_code_at(bci);
+
+    switch (code) {
+      case Bytecodes::_new:
+      case Bytecodes::_anewarray:
+      case Bytecodes::_multianewarray:
+      case Bytecodes::_instanceof:
+      case Bytecodes::_checkcast: {
+        Bytecode bc(caller_method(), caller_method->bcp_from(bci));
+        constantTag tag = caller_method->constants()->tag_at(bc.get_index_u2(code));
+        if (tag.is_unresolved_klass_in_error()) {
+          return false; // throws resolution error
+        }
+        break;
+      }
+
+      default: break;
+    }
+  }
+  return true;
+}
+
 void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
 #ifndef PRODUCT
   if (PrintC1Statistics) {
@@ -1281,10 +1312,12 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
   frame caller_frame = runtime_frame.sender(&reg_map);
   assert(caller_frame.is_compiled_frame(), "Wrong frame type");
 
-  // Make sure the nmethod is invalidated, i.e. made not entrant.
-  nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
-  if (nm != NULL) {
-    nm->make_not_entrant();
+  if (is_patching_needed(current, stub_id)) {
+    // Make sure the nmethod is invalidated, i.e. made not entrant.
+    nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
+    if (nm != NULL) {
+      nm->make_not_entrant();
+    }
   }
 
   Deoptimization::deoptimize_frame(current, caller_frame.id());

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -23,9 +23,10 @@
  */
 
 #include "precompiled.hpp"
-#include "ci/ciCallSite.hpp"
 #include "ci/ciConstant.hpp"
 #include "ci/ciField.hpp"
+#include "ci/ciKlass.hpp"
+#include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciStreams.hpp"
 #include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
@@ -189,6 +190,25 @@ ciKlass* ciBytecodeStream::get_klass(bool& will_link) {
   VM_ENTRY_MARK;
   constantPoolHandle cpool(THREAD, _method->get_Method()->constants());
   return CURRENT_ENV->get_klass_by_index(cpool, get_klass_index(), will_link, _holder);
+}
+
+// ciBytecodeStream::get_klass
+//
+// If this bytecode is a new, newarray, multianewarray, instanceof,
+// or checkcast, get the referenced klass. Retuns an unloaded ciKlass
+// if the referenced klass is not accessible.
+ciKlass* ciBytecodeStream::get_klass() {
+  bool will_link;
+  ciKlass* klass = get_klass(will_link);
+  if (!will_link && klass->is_loaded()) { // klass not accessible
+    if (klass->is_array_klass()) {
+      assert(!klass->is_type_array_klass(), "");
+      klass = ciEnv::unloaded_ciobjarrayklass();
+    } else {
+      klass = ciEnv::unloaded_ciinstance_klass();
+    }
+  }
+  return klass;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -219,6 +219,7 @@ public:
 
   // If this bytecode is a new, newarray, multianewarray, instanceof,
   // or checkcast, get the referenced klass.
+  ciKlass* get_klass();
   ciKlass* get_klass(bool& will_link);
   int get_klass_index() const;
 

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -77,9 +77,11 @@ class Bytecode: public StackObj {
   int get_index_u2(Bytecodes::Code bc, bool is_wide = false) const {
     assert_same_format_as(bc, is_wide); assert_index_size(2, bc, is_wide);
     address p = addr_at(is_wide ? 2 : 1);
-    if (can_use_native_byte_order(bc, is_wide))
+    if (can_use_native_byte_order(bc, is_wide)) {
       return Bytes::get_native_u2(p);
-    else  return Bytes::get_Java_u2(p);
+    } else {
+      return Bytes::get_Java_u2(p);
+    }
   }
   int get_index_u1_cpcache(Bytecodes::Code bc) const {
     assert_same_format_as(bc); assert_index_size(1, bc);

--- a/test/hotspot/jtreg/compiler/c1/KlassAccessCheck.jasm
+++ b/test/hotspot/jtreg/compiler/c1/KlassAccessCheck.jasm
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler/c1;
+
+super public class KlassAccessCheck
+  version 51:0
+{
+
+  public static Method testNewInstance:"()V"
+  stack 2 locals 0
+  {
+   new class compiler/c1/types/PackagePrivateClass;
+   return;
+  }
+
+
+  public static Method testNewArray:"()[Ljava/lang/Object;"
+    stack 1 locals 0
+  {
+   iconst_1;
+   anewarray class compiler/c1/types/PackagePrivateClass;
+   areturn;
+  }
+
+  public static Method testMultiNewArray:"()[[Ljava/lang/Object;"
+  stack 2 locals 1
+  {
+   iconst_1;
+   iconst_1;
+   multianewarray  class "[[Lcompiler/c1/types/PackagePrivateClass;",  2;
+   areturn;
+  }
+
+  public static Method testCheckCast:"(Ljava/lang/Object;)Ljava/lang/Object;"
+  stack 1 locals 2
+  {
+   aload_0;
+   checkcast class compiler/c1/types/PackagePrivateClass;
+   areturn;
+  }
+
+  public static Method testCheckCastArr:"(Ljava/lang/Object;)Ljava/lang/Object;"
+  stack 1 locals 2
+  {
+   aload_0;
+   checkcast class "[Lcompiler/c1/types/PackagePrivateClass;";
+   areturn;
+  }
+
+  public static Method testInstanceOf:"(Ljava/lang/Object;)Z"
+  stack 1 locals 2
+  {
+   aload_0;
+   instanceof class compiler/c1/types/PackagePrivateClass;
+   ireturn;
+  }
+
+  public static Method testInstanceOfArr:"(Ljava/lang/Object;)Z"
+  stack 1 locals 2
+  {
+   aload_0;
+   instanceof class "[Lcompiler/c1/types/PackagePrivateClass;";
+   ireturn;
+  }
+} // end Class KlassAccessCheck

--- a/test/hotspot/jtreg/compiler/c1/KlassAccessCheckPackagePrivate.jasm
+++ b/test/hotspot/jtreg/compiler/c1/KlassAccessCheckPackagePrivate.jasm
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler/c1/types;
+
+super class PackagePrivateClass
+ version 51:0
+{}
+

--- a/test/hotspot/jtreg/compiler/c1/KlassAccessCheckTest.java
+++ b/test/hotspot/jtreg/compiler/c1/KlassAccessCheckTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293044
+ * @requires vm.compiler1.enabled
+ * @compile KlassAccessCheckPackagePrivate.jasm
+ * @compile KlassAccessCheck.jasm
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 compiler.c1.KlassAccessCheckTest
+ */
+
+package compiler.c1;
+
+public class KlassAccessCheckTest {
+    static void test(Runnable r) {
+        for (int i = 0; i < 1000; ++i) {
+            try {
+                r.run();
+                throw new AssertionError("No IllegalAccessError thrown");
+            } catch (IllegalAccessError e) {
+                // Expected
+            } catch (AssertionError e) {
+                throw e; // rethrow
+            } catch (Throwable e) {
+                throw new AssertionError("Wrong exception thrown", e);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        test(() -> KlassAccessCheck.testNewInstance());
+        test(() -> KlassAccessCheck.testNewArray());
+        test(() -> KlassAccessCheck.testMultiNewArray());
+        test(() -> KlassAccessCheck.testCheckCast(42));
+        test(() -> KlassAccessCheck.testCheckCastArr(new Integer[0]));
+        test(() -> KlassAccessCheck.testInstanceOf(42));
+        test(() -> KlassAccessCheck.testInstanceOfArr(new Integer[0]));
+        System.out.println("TEST PASSED");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8293044](https://bugs.openjdk.java.net/browse/JDK-8293044). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293044](https://bugs.openjdk.org/browse/JDK-8293044): C1: Missing access check on non-accessible class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk19u pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/30.diff">https://git.openjdk.org/jdk19u/pull/30.diff</a>

</details>
