### PR TITLE
8290705: StringConcat::validate_mem_flow asserts with "unexpected user: StoreI"

### DIFF
--- a/test/hotspot/jtreg/compiler/stringopts/SideEffectBeforeConstructor.jasm
+++ b/test/hotspot/jtreg/compiler/stringopts/SideEffectBeforeConstructor.jasm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class compiler/stringopts/SideEffectBeforeConstructor
+	version 51:0
+{
+  public static Field result:I;
+
+  static Method "<clinit>":"()V"
+	stack 2 locals 0
+  {
+		iconst_0;
+		putstatic	Field result:"I";
+		return;
+  }
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+
+  public static Method test:"(Ljava/lang/String;)V"
+	stack 4 locals 1
+  {
+		new	class java/lang/StringBuffer;
+		dup;
+		getstatic	Field result:"I";
+		iconst_1;
+		iadd;
+		putstatic	Field result:"I";
+		aload_0;
+		invokespecial	Method java/lang/StringBuffer."<init>":"(Ljava/lang/String;)V";
+		invokevirtual	Method java/lang/StringBuffer.toString:"()Ljava/lang/String;";
+		return;
+  }
+}

--- a/test/hotspot/jtreg/compiler/stringopts/TestSideEffectBeforeConstructor.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestSideEffectBeforeConstructor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290705
+ * @summary Test correctness of the string concatenation optimization with
+ *          a store between StringBuffer allocation and constructor invocation.
+ * @compile SideEffectBeforeConstructor.jasm
+ * @run main/othervm -Xbatch compiler.stringopts.TestSideEffectBeforeConstructor
+ */
+
+package compiler.stringopts;
+
+public class TestSideEffectBeforeConstructor {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 100_000; ++i) {
+            try {
+                SideEffectBeforeConstructor.test(null);
+            } catch (NullPointerException npe) {
+                // Expected
+            }
+        }
+        if (SideEffectBeforeConstructor.result != 100_000) {
+            throw new RuntimeException("Unexpected result: " + SideEffectBeforeConstructor.result);
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8290705](https://bugs.openjdk.java.net/browse/JDK-8290705). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290705](https://bugs.openjdk.org/browse/JDK-8290705): StringConcat::validate_mem_flow asserts with "unexpected user: StoreI"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jdk19u pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/34.diff">https://git.openjdk.org/jdk19u/pull/34.diff</a>

</details>
