### PR TITLE
8290496: riscv: Fix build warnings-as-errors with GCC 11

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -312,18 +312,14 @@ class NativeCall: public NativeInstruction {
 inline NativeCall* nativeCall_at(address addr) {
   assert_cond(addr != NULL);
   NativeCall* call = (NativeCall*)(addr - NativeCall::instruction_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
 inline NativeCall* nativeCall_before(address return_address) {
   assert_cond(return_address != NULL);
   NativeCall* call = (NativeCall*)(return_address - NativeCall::return_address_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
@@ -363,7 +359,7 @@ class NativeMovConstReg: public NativeInstruction {
   }
 
   intptr_t data() const;
-  void  set_data(intptr_t x);
+  void set_data(intptr_t x);
 
   void flush() {
     if (!maybe_cpool_ref(instruction_address())) {
@@ -371,8 +367,8 @@ class NativeMovConstReg: public NativeInstruction {
     }
   }
 
-  void  verify();
-  void  print();
+  void verify();
+  void print();
 
   // Creation
   inline friend NativeMovConstReg* nativeMovConstReg_at(address addr);
@@ -382,55 +378,53 @@ class NativeMovConstReg: public NativeInstruction {
 inline NativeMovConstReg* nativeMovConstReg_at(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
 inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_size - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
-// RISCV should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
+// RISCV should not use C1 runtime patching, but still implement
+// NativeMovRegMem to keep some compilers happy.
 class NativeMovRegMem: public NativeInstruction {
  public:
-  int instruction_start() const {
-    Unimplemented();
-    return 0;
-  }
+  enum RISCV_specific_constants {
+    instruction_size            =    NativeInstruction::instruction_size,
+    instruction_offset          =    0,
+    data_offset                 =    0,
+    next_instruction_offset     =    NativeInstruction::instruction_size
+  };
 
-  address instruction_address() const {
-    Unimplemented();
-    return NULL;
-  }
+  int instruction_start() const { return instruction_offset; }
 
-  int num_bytes_to_end_of_patch() const {
-    Unimplemented();
-    return 0;
-  }
+  address instruction_address() const { return addr_at(instruction_offset); }
+
+  int num_bytes_to_end_of_patch() const { return instruction_offset + instruction_size; }
 
   int offset() const;
 
   void set_offset(int x);
 
-  void add_offset_in_bytes(int add_offset) { Unimplemented(); }
+  void add_offset_in_bytes(int add_offset) {
+    set_offset(offset() + add_offset);
+  }
 
   void verify();
   void print();
 
  private:
-  inline friend NativeMovRegMem* nativeMovRegMem_at (address addr);
+  inline friend NativeMovRegMem* nativeMovRegMem_at(address addr);
 };
 
-inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
-  Unimplemented();
-  return NULL;
+inline NativeMovRegMem* nativeMovRegMem_at(address addr) {
+  NativeMovRegMem* test = (NativeMovRegMem*)(addr - NativeMovRegMem::instruction_offset);
+  DEBUG_ONLY(test->verify());
+  return test;
 }
 
 class NativeJump: public NativeInstruction {
@@ -461,9 +455,7 @@ class NativeJump: public NativeInstruction {
 
 inline NativeJump* nativeJump_at(address addr) {
   NativeJump* jump = (NativeJump*)(addr - NativeJump::instruction_offset);
-#ifdef ASSERT
-  jump->verify();
-#endif
+  DEBUG_ONLY(jump->verify());
   return jump;
 }
 

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -171,7 +171,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Entry arguments:
-  //  t2: CompiledICHolder
+  //  t1: CompiledICHolder
   //  j_rarg0: Receiver
 
   // This stub is called from compiled code which has no callee-saved registers,


### PR DESCRIPTION
Please review this backport to jdk19u.
Backport of [JDK-8290496](https://bugs.openjdk.java.net/browse/JDK-8290496). Applies cleanly. Approval is pending.

Build without `--disable-warnings-as-errors` after this fix passed on unmatched board with GCC11

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290496](https://bugs.openjdk.org/browse/JDK-8290496): riscv: Fix build warnings-as-errors with GCC 11


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jdk19u pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/40.diff">https://git.openjdk.org/jdk19u/pull/40.diff</a>

</details>
