### PR TITLE
8290900: Build failure with Clang 14+ due to function warning attribute

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -69,7 +69,10 @@
 
 #endif // clang/gcc version check
 
-#if (__GNUC__ >= 10) || (defined(__clang_major__) && (__clang_major__ >= 14))
+#if (__GNUC__ >= 10)
+// TODO: Re-enable warning attribute for Clang once
+// https://github.com/llvm/llvm-project/issues/56519 is fixed and released.
+// || (defined(__clang_major__) && (__clang_major__ >= 14))
 
 // Use "warning" attribute to detect uses of "forbidden" functions.
 //
@@ -92,6 +95,6 @@
   __VA_ARGS__                                           \
   PRAGMA_DIAG_POP
 
-#endif // gcc10+ or clang14+
+#endif // gcc10+
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP


### PR DESCRIPTION
Hi all,

Could anyone review this backport of https://bugs.openjdk.org/browse/JDK-8290900? It applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290900](https://bugs.openjdk.org/browse/JDK-8290900): Build failure with Clang 14+ due to function warning attribute


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/jdk19u pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/44.diff">https://git.openjdk.org/jdk19u/pull/44.diff</a>

</details>
