### PR TITLE
8295268: Optimized builds are broken due to incorrect assert_is_rfp shortcuts

### DIFF
--- a/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
@@ -33,7 +33,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap


### PR DESCRIPTION
Clean backport to unbreak optimized builds on some platforms.

Additional testing:
 - [x] Linux arm `optimized` build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295268](https://bugs.openjdk.org/browse/JDK-8295268): Optimized builds are broken due to incorrect assert_is_rfp shortcuts


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jdk19u pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/50.diff">https://git.openjdk.org/jdk19u/pull/50.diff</a>

</details>
