### PR TITLE
8293701: jdeps InverseDepsAnalyzer runs into NoSuchElementException: No value present

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,9 +145,12 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
                 .forEach(m -> {
                     builder.addNode(m);
                     m.descriptor().requires().stream()
-                        .map(Requires::name)
-                        .map(configuration::findModule)  // must be present
-                        .forEach(v -> builder.addEdge(v.get(), m));
+                        // filter "requires static" if the module is not resolved in the configuration
+                        .filter(req -> !req.modifiers().contains(Requires.Modifier.STATIC)
+                            || configuration.findModule(req.name()).isPresent())
+                            .map(Requires::name)
+                            .map(configuration::findModule)  // must be present
+                            .forEach(v -> builder.addEdge(v.get(), m));
                 });
 
             // add the dependences from the analysis

--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293701
+ * @library ../lib
+ * @build CompilerUtils
+ * @run testng OptionalDependencyTest
+ * @summary Tests optional dependency handling
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.spi.ToolProvider;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class OptionalDependencyTest {
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+
+    private static final Path MODS_DIR = Paths.get("mods");
+
+    private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar").orElseThrow();
+    private static final Set<String> modules = Set.of("m1", "m2", "m3");
+
+    @BeforeTest
+    public void compileAll() throws Exception {
+        CompilerUtils.cleanDir(MODS_DIR);
+        modules.forEach(mn ->
+                assertTrue(CompilerUtils.compileModule(SRC_DIR, MODS_DIR, mn)));
+
+        Path m1 = MODS_DIR.resolve("m1");
+        Path m2 = MODS_DIR.resolve("m2");
+        Path m3 = MODS_DIR.resolve("m3");
+        jar("cf", "m1.jar", "-C", m1.toString(), "p1/P.class",
+                "-C", m1.toString(), "module-info.class");
+        jar("cf", "m2.jar", "-C", m2.toString(), "p2/Q.class",
+                "-C", m2.toString(), "module-info.class");
+        jar("cf", "m3.jar", "-C", m3.toString(), "p3/R.class",
+                "-C", m3.toString(), "module-info.class");
+    }
+
+    /*
+     * Test if a requires static dependence is not resolved in the configuration.
+     */
+    @Test
+    public void optionalDependenceNotResolved() {
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+                                                  "--inverse",
+                                                  "--package", "p2", "m1.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc == 0);
+    }
+
+    /*
+     * Test if a requires static dependence is resolved in the configuration.
+     */
+    @Test
+    public void optionalDependenceResolved() {
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+                                                  "--inverse", "--add-modules", "m3",
+                                                  "--package", "p2", "m1.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc == 0);
+    }
+
+    private static void jar(String... options) {
+        int rc = JAR_TOOL.run(System.out, System.err, options);
+        assertTrue(rc == 0);
+    }
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m1/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m1/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m1 {
+    requires transitive m2;
+    exports p1;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m1/p1/P.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m1/p1/P.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p1;
+public class P {
+    public void m() {}
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m2/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m2/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m2 {
+    requires static m3;
+    exports p2;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m2/p2/Q.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m2/p2/Q.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p2;
+public class Q {
+    @p3.R
+    public void m() {}
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m3/module-info.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m3/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m3 {
+    exports p3;
+}

--- a/test/langtools/tools/jdeps/optionalDependency/src/m3/p3/R.java
+++ b/test/langtools/tools/jdeps/optionalDependency/src/m3/p3/R.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p3;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.SOURCE)
+public @interface R {
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8293701](https://bugs.openjdk.org/browse/JDK-8293701), commit [953ce8da](https://github.com/openjdk/jdk/commit/953ce8da2c7ddd60b09a18c7875616a2477e5ba5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 5 Oct 2022 and was reviewed by Mandy Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293701](https://bugs.openjdk.org/browse/JDK-8293701): jdeps InverseDepsAnalyzer runs into NoSuchElementException: No value present


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jdk19u pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/54.diff">https://git.openjdk.org/jdk19u/pull/54.diff</a>

</details>
