### PR TITLE
8294840: langtools OptionalDependencyTest.java use File.pathSeparator

### DIFF
--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -30,6 +30,7 @@
  * @summary Tests optional dependency handling
  */
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -71,7 +72,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceNotResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);
@@ -83,7 +84,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse", "--add-modules", "m3",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8294840](https://bugs.openjdk.org/browse/JDK-8294840), commit [f531dae4](https://github.com/openjdk/jdk/commit/f531dae4a0ffd2a5663cf4a4bde581d68fc728d5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 5 Oct 2022 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294840](https://bugs.openjdk.org/browse/JDK-8294840): langtools OptionalDependencyTest.java use File.pathSeparator


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk19u pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/60.diff">https://git.openjdk.org/jdk19u/pull/60.diff</a>

</details>
