### PR TITLE
8292159: TYPE_USE annotations on generic type arguments of record components discarded

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -32,6 +32,7 @@ import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.RecordComponent;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.CapturedType;
@@ -84,6 +85,7 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Names;
 
+import static com.sun.tools.javac.code.Flags.RECORD;
 import static com.sun.tools.javac.code.Kinds.Kind.*;
 
 /**
@@ -1301,6 +1303,16 @@ public class TypeAnnotations {
             scan(tree.vartype);
             if (!sigOnly) {
                 scan(tree.init);
+            }
+
+            // Now that type and declaration annotations have been segregated into their own buckets ...
+            if (sigOnly) {
+                if (tree.sym != null && tree.sym.getKind() == ElementKind.FIELD && (tree.sym.flags_field & RECORD) != 0) {
+                    RecordComponent rc = ((ClassSymbol)tree.sym.owner).getRecordComponent(tree.sym);
+                    rc.setTypeAttributes(tree.sym.getRawTypeAttributes());
+                    // to get all the type annotations applied to the type
+                    rc.type = tree.sym.type;
+                }
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2998,9 +2998,15 @@ public class Check {
                     rc.appendAttributes(s.getRawAttributes().stream().filter(anno ->
                             Arrays.stream(getTargetNames(anno.type.tsym)).anyMatch(name -> name == names.RECORD_COMPONENT)
                     ).collect(List.collector()));
-                    rc.setTypeAttributes(s.getRawTypeAttributes());
-                    // to get all the type annotations applied to the type
-                    rc.type = s.type;
+
+                    /* At this point, we used to carry over any type annotations from the VARDEF to the record component, but
+                     * that is problematic, since we get here only when *some* annotation is applied to the SE5 (declaration)
+                     * annotation location, inadvertently failing to carry over the type annotations when the VarDef has no
+                     * annotations in the SE5 annotation location.
+                     *
+                     * Now type annotations are assigned to record components in a method that would execute irrespective of
+                     * whether there are SE5 annotations on a VarDef viz com.sun.tools.javac.code.TypeAnnotations.TypeAnnotationPositions.visitVarDef
+                     */
                 }
             }
         }

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -1479,6 +1479,57 @@ public class RecordCompilationTests extends CompilationTestCase {
         setCompileOptions(previousOptions);
     }
 
+    // JDK-8292159: TYPE_USE annotations on generic type arguments
+    //              of record components discarded
+    public void testOnlyTypeAnnotationsOnComponentField() throws Exception {
+        String code =
+                """
+                import java.lang.annotation.*;
+                import java.util.List;
+                @Target({ElementType.TYPE_USE})
+                @Retention(RetentionPolicy.RUNTIME)
+                @interface Anno { }
+                record R(List<@Anno String> s) {}
+                """;
+
+        File dir = assertOK(true, code);
+
+        ClassFile classFile = ClassFile.read(findClassFileOrFail(dir, "R.class"));
+
+        // field first
+        Assert.check(classFile.fields.length == 1);
+        Field field = classFile.fields[0];
+        checkTypeAnno(
+                classFile,
+                (RuntimeVisibleTypeAnnotations_attribute) findAttributeOrFail(field.attributes, RuntimeVisibleTypeAnnotations_attribute.class),
+                "FIELD",
+                "Anno");
+
+        // checking for the annotation on the corresponding parameter of the canonical constructor
+        Method init = findMethodOrFail(classFile, "<init>");
+        checkTypeAnno(
+                classFile,
+                (RuntimeVisibleTypeAnnotations_attribute) findAttributeOrFail(init.attributes, RuntimeVisibleTypeAnnotations_attribute.class),
+                "METHOD_FORMAL_PARAMETER", "Anno");
+
+        // checking for the annotation in the accessor
+        Method accessor = findMethodOrFail(classFile, "s");
+        checkTypeAnno(
+                classFile,
+                (RuntimeVisibleTypeAnnotations_attribute) findAttributeOrFail(accessor.attributes, RuntimeVisibleTypeAnnotations_attribute.class),
+                "METHOD_RETURN", "Anno");
+
+        // checking for the annotation in the Record attribute
+        Record_attribute record = (Record_attribute) findAttributeOrFail(classFile.attributes, Record_attribute.class);
+        Assert.check(record.component_count == 1);
+        checkTypeAnno(
+                classFile,
+                (RuntimeVisibleTypeAnnotations_attribute) findAttributeOrFail(
+                            record.component_info_arr[0].attributes,
+                                RuntimeVisibleTypeAnnotations_attribute.class),
+                        "FIELD", "Anno");
+    }
+
     private void checkTypeAnno(ClassFile classFile,
                                RuntimeTypeAnnotations_attribute rtAnnos,
                                String positionType,


### PR DESCRIPTION
Backport-of: 4d9a1cd26fa0cda902aafcccd6e02bd7bc60bbb3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292159](https://bugs.openjdk.org/browse/JDK-8292159): TYPE_USE annotations on generic type arguments of record components discarded


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.org/jdk19u pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/62.diff">https://git.openjdk.org/jdk19u/pull/62.diff</a>

</details>
