### PR TITLE
8296733: JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
@@ -158,7 +158,7 @@ final class RandomAccessFileInstrumentor {
             write(b);
             bytesWritten = b.length;
         } finally {
-            long duration = EventConfiguration.timestamp();
+            long duration = EventConfiguration.timestamp() - start;
             if (eventConfiguration.shouldCommit(duration)) {
                 FileWriteEvent.commit(start, duration, path, bytesWritten);
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8296733](https://bugs.openjdk.org/browse/JDK-8296733), commit [ced88a2f](https://github.com/openjdk/jdk/commit/ced88a2fd9a35e0e027661ef1f3c5ea3a5fff9e0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Erik Gahlin on 11 Nov 2022 and was reviewed by Christoph Langer and Markus Grönlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296733](https://bugs.openjdk.org/browse/JDK-8296733): JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk19u pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/65.diff">https://git.openjdk.org/jdk19u/pull/65.diff</a>

</details>
