### PR TITLE
8295926: RISC-V: C1: Fix LIRGenerator::do_LibmIntrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -675,19 +675,30 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
 void LIRGenerator::do_LibmIntrinsic(Intrinsic* x) {
   LIRItem value(x->argument_at(0), this);
   value.set_destroys_register();
+
   LIR_Opr calc_result = rlock_result(x);
   LIR_Opr result_reg = result_register_for(x->type());
+
   CallingConvention* cc = NULL;
-  BasicTypeList signature(1);
-  signature.append(T_DOUBLE);
-  if (x->id() == vmIntrinsics::_dpow) { signature.append(T_DOUBLE); }
-  cc = frame_map()->c_calling_convention(&signature);
-  value.load_item_force(cc->at(0));
+
   if (x->id() == vmIntrinsics::_dpow) {
     LIRItem value1(x->argument_at(1), this);
+
     value1.set_destroys_register();
+
+    BasicTypeList signature(2);
+    signature.append(T_DOUBLE);
+    signature.append(T_DOUBLE);
+    cc = frame_map()->c_calling_convention(&signature);
+    value.load_item_force(cc->at(0));
     value1.load_item_force(cc->at(1));
+  } else {
+    BasicTypeList signature(1);
+    signature.append(T_DOUBLE);
+    cc = frame_map()->c_calling_convention(&signature);
+    value.load_item_force(cc->at(0));
   }
+
   switch (x->id()) {
     case vmIntrinsics::_dexp:
       if (StubRoutines::dexp() != NULL) { __ call_runtime_leaf(StubRoutines::dexp(), getThreadTemp(), result_reg, cc->args()); }

--- a/test/hotspot/jtreg/compiler/floatingpoint/TestLibmIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestLibmIntrinsics.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test libm intrinsics
+ * @library /test/lib /
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+ *                   compiler.floatingpoint.TestLibmIntrinsics
+ */
+
+package compiler.floatingpoint;
+
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.whitebox.WhiteBox;
+
+import java.lang.reflect.Method;
+
+public class TestLibmIntrinsics {
+
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    private static final double pi = 3.1415926;
+
+    private static final double expected = 2.5355263553695413;
+
+    static double m() {
+        return Math.pow(pi, Math.sin(Math.cos(Math.tan(Math.log(Math.log10(Math.exp(pi)))))));
+    }
+
+    static public void main(String[] args) throws NoSuchMethodException {
+        Method test_method = compiler.floatingpoint.TestLibmIntrinsics.class.getDeclaredMethod("m");
+
+        double interpreter_result = m();
+
+        // Compile with C1 if possible
+        WHITE_BOX.enqueueMethodForCompilation(test_method, CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE);
+
+        double c1_result = m();
+
+        WHITE_BOX.deoptimizeMethod(test_method);
+
+        // Compile it with C2 if possible
+        WHITE_BOX.enqueueMethodForCompilation(test_method, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+
+        double c2_result = m();
+
+        if (interpreter_result != c1_result ||
+            interpreter_result != c2_result ||
+            c1_result != c2_result) {
+            System.out.println("interpreter = " + interpreter_result + " c1 = " + c1_result + " c2 = " + c2_result);
+            throw new RuntimeException("Test Failed");
+        }
+    }
+}


### PR DESCRIPTION
Clean backport from 20 for RISC-V backend: https://github.com/openjdk/jdk/commit/1fdbb1ba337b07dbcfb3c28c4fdeba74fee113dc

Tier1~2 testing passed, including the added jtreg test in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295926](https://bugs.openjdk.org/browse/JDK-8295926): RISC-V: C1: Fix LIRGenerator::do_LibmIntrinsic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jdk19u pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/70.diff">https://git.openjdk.org/jdk19u/pull/70.diff</a>

</details>
