### PR TITLE
8296771: RISC-V: C2: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3208,6 +3208,7 @@ operand iRegP()
   match(RegP);
   match(iRegPNoSp);
   match(iRegP_R10);
+  match(iRegP_R15);
   match(javaThread_RegP);
   op_cost(0);
   format %{ %}


### PR DESCRIPTION
This is a fix for a fast debug build assertion failure, and the impact is small.
Clean backport from 20.

Testing currently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296771](https://bugs.openjdk.org/browse/JDK-8296771): RISC-V: C2: assert(false) failed: bad AD file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk19u pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/79.diff">https://git.openjdk.org/jdk19u/pull/79.diff</a>

</details>
