### PR TITLE
Backport d3eba859f9c87465a8f1c0dfd6dd5aef368d5853

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -5105,7 +5105,7 @@ operand iRegP()
   match(iRegP_R0);
   //match(iRegP_R2);
   //match(iRegP_R4);
-  //match(iRegP_R5);
+  match(iRegP_R5);
   match(thread_RegP);
   op_cost(0);
   format %{ %}

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +25,15 @@
 /**
  * @test
  * @bug 8253566
+ * @bug 8295414
  * @summary clazz.isAssignableFrom will return false for interface implementors
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
+ * @run main/othervm -XX:-BackgroundCompilation
+ *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */
 


### PR DESCRIPTION
Backport of [JDK-8295414](https://bugs.openjdk.java.net/browse/JDK-8295414). Applies cleanly. Approval is pending.

Thanks,
Tobias