### PR TITLE
8295264: Fix PaX check on RISC-V

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4328,13 +4328,13 @@ static void check_pax(void) {
 #ifndef ZERO
   size_t size = os::Linux::page_size();
 
-  void* p = ::mmap(NULL, size, PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  void* p = ::mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
   if (p == MAP_FAILED) {
     log_debug(os)("os_linux.cpp: check_pax: mmap failed (%s)" , os::strerror(errno));
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "failed to allocate memory for PaX check.");
   }
 
-  int res = ::mprotect(p, size, PROT_WRITE|PROT_EXEC);
+  int res = ::mprotect(p, size, PROT_READ|PROT_WRITE|PROT_EXEC);
   if (res == -1) {
     log_debug(os)("os_linux.cpp: check_pax: mprotect failed (%s)" , os::strerror(errno));
     vm_exit_during_initialization(


### PR DESCRIPTION
On Linux RISC-V, PROT_WRITE doesn't imply PROT_READ [1]

The fix is to pass PROT_READ|PROT_WRITE. That matches all other calls to mmap in hotspot.

[1] https://lkml.org/lkml/2022/9/8/1066

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295264](https://bugs.openjdk.org/browse/JDK-8295264): Fix PaX check on RISC-V ⚠️ Issue is not open.


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/jdk19u pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/91.diff">https://git.openjdk.org/jdk19u/pull/91.diff</a>

</details>
