### PR TITLE
8297147: UnexpectedSourceImageSize test times out on slow machines when fastdebug is used

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
@@ -44,6 +44,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
  * @test
  * @bug 8264666
  * @summary No exception or errors should occur in ColorConvertOp.filter().
+ * @run main/othervm/timeout=600 UnexpectedSourceImageSize
  */
 public final class UnexpectedSourceImageSize {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8297147](https://bugs.openjdk.org/browse/JDK-8297147), commit [88957a7c](https://github.com/openjdk/jdk/commit/88957a7ce8932b95e3a18e6a7d1ceb3b7f60c781) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 22 Nov 2022 and was reviewed by Thomas Stuefe and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297147](https://bugs.openjdk.org/browse/JDK-8297147): UnexpectedSourceImageSize test times out on slow machines when fastdebug is used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jdk19u pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/93.diff">https://git.openjdk.org/jdk19u/pull/93.diff</a>

</details>
