### PR TITLE
8290164: compiler/runtime/TestConstantsInError.java fails on riscv

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
@@ -130,7 +130,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
             results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_C2/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_C2/.*::test \\(3 bytes\\)   made not entrant");
             } else {
@@ -168,7 +168,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
                    .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_MH4/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_MH1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MH2/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)   made not entrant")
@@ -191,7 +191,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
             results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)   made not entrant");
             } else {
@@ -235,7 +235,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
                    .shouldMatch("Test_CD3.*::test \\(3 bytes\\)$")
                    .shouldMatch("Test_CD4.*::test \\(3 bytes\\)$");
 
-            if (isC1 && Platform.isAArch64()) { // no code patching
+            if (isC1 && (Platform.isAArch64() || Platform.isRISCV64())) { // no code patching
                 results.shouldMatch("Test_CD1.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_CD2.*::test \\(3 bytes\\)   made not entrant")
                        .shouldMatch("Test_CD3.*::test \\(3 bytes\\)   made not entrant")


### PR DESCRIPTION
Please review this backport to jdk19u. Backport of [JDK-8290164](https://bugs.openjdk.org/browse/JDK-8290164).
Applies cleanly. Approval is pending.

Testing:

- compiler/runtime/TestConstantsInError.java passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290164](https://bugs.openjdk.org/browse/JDK-8290164): compiler/runtime/TestConstantsInError.java fails on riscv


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk19u pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/95.diff">https://git.openjdk.org/jdk19u/pull/95.diff</a>

</details>
