### PR TITLE
8296463: Memory leak in JVM_StartThread with the integration of Virtual threads

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1229,10 +1229,11 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
 
 JavaThread::~JavaThread() {
 
-  // Ask ServiceThread to release the threadObj OopHandle
+  // Ask ServiceThread to release the OopHandles
   ServiceThread::add_oop_handle_release(_threadObj);
   ServiceThread::add_oop_handle_release(_vthread);
   ServiceThread::add_oop_handle_release(_jvmti_vthread);
+  ServiceThread::add_oop_handle_release(_extentLocalCache);
 
   // Return the sleep event to the free list
   ParkEvent::Release(_SleepEvent);


### PR DESCRIPTION
Backport of  https://github.com/openjdk/jdk/commit/7b3984cb5a08edb99a233c28331c00b25457d664

It didn't apply cleanly because of  the code being factored out of `thread.cpp` into `javaThread.cpp` in JDK 20.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296463](https://bugs.openjdk.org/browse/JDK-8296463): Memory leak in JVM_StartThread with the integration of Virtual threads


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk19u pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/97.diff">https://git.openjdk.org/jdk19u/pull/97.diff</a>

</details>
