### PR TITLE
8282463: javax/sound/sampled/Clip/DataPusherThreadCheck.java fails

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/DataPusherThreadCheck.java
+++ b/test/jdk/javax/sound/sampled/Clip/DataPusherThreadCheck.java
@@ -28,6 +28,8 @@ import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.DataLine;
 import java.applet.AudioClip;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -49,6 +51,10 @@ public class DataPusherThreadCheck {
         try {
             AudioFormat format =
                     new AudioFormat(PCM_SIGNED, 44100, 8, 1, 1, 44100, false);
+            DataLine.Info info = new DataLine.Info(Clip.class, format);
+            if (!(AudioSystem.isLineSupported(info)) ) {
+                return; // the test is not applicable
+            }
             int dataSize = 6000*1000 * format.getFrameSize();
             InputStream in = new ByteArrayInputStream(new byte[dataSize]);
             AudioInputStream audioStream = new AudioInputStream(in, format, NOT_SPECIFIED);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2e716375](https://github.com/openjdk/jdk/commit/2e7163759c75cab6ab5ffa04c13d32ccc95f9719) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Andrey Turbanov on 30 Oct 2022 and was reviewed by Phil Race and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282463](https://bugs.openjdk.org/browse/JDK-8282463): javax/sound/sampled/Clip/DataPusherThreadCheck.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19u pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jdk19u pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19u/pull/105.diff">https://git.openjdk.org/jdk19u/pull/105.diff</a>

</details>
